### PR TITLE
fix service account name when create_service_account is set

### DIFF
--- a/modules/gitlab-runner/config.tf
+++ b/modules/gitlab-runner/config.tf
@@ -17,11 +17,7 @@ locals {
   %{~if var.build_job_default_container_image != null~}
     image = "${var.build_job_default_container_image}"
   %{~endif~}
-  %{~if var.create_service_account == true~}
-    service_account = "${var.release_name}-${var.service_account}"
-  %{~else~}
     service_account = "${var.service_account}"
-  %{~endif~}
     image_pull_secrets = ${jsonencode(var.image_pull_secrets)}
     privileged      = ${var.build_job_privileged}
     [runners.kubernetes.affinity]


### PR DESCRIPTION
The setting for the service accountname looks wrong.

Looking at the helm template for the service-account it should not have that name which is configured by default:

- https://gitlab.com/gitlab-org/charts/gitlab-runner/-/blob/main/templates/service-account.yaml#L9
- https://gitlab.com/gitlab-org/charts/gitlab-runner/-/blob/main/templates/_helpers.tpl#L13