### PR TITLE
feat: add keycloak helm wrapper module

### DIFF
--- a/.github/workflows/checkov.yaml
+++ b/.github/workflows/checkov.yaml
@@ -25,6 +25,7 @@ jobs:
           - modules/horizon-monitor
           - modules/istio
           - modules/kafka
+          - modules/keycloak
           - modules/keeper-reader
           - modules/kyverno
           - modules/loki

--- a/.github/workflows/terraform-test.yaml
+++ b/.github/workflows/terraform-test.yaml
@@ -21,6 +21,7 @@ jobs:
           - modules/gitlab-runner
           - modules/horizon-monitor
           - modules/istio
+          - modules/keycloak
           - modules/keeper-reader
           - modules/kyverno
           - modules/loki

--- a/.github/workflows/tflint.yaml
+++ b/.github/workflows/tflint.yaml
@@ -26,6 +26,7 @@ jobs:
           - modules/horizon-monitor
           - modules/istio
           - modules/kafka
+          - modules/keycloak
           - modules/keeper-reader
           - modules/kyverno
           - modules/loki

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+terraform 1.14.8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,10 @@
 # terraform-any-shared Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-03-19
+Auto-generated from all feature plans. Last updated: 2026-03-26
 
 ## Active Technologies
+- Terraform ~> 1.3 + Helm provider, Kubernetes provider, GitHub Actions, pre-commit, terraform-docs, tflint, checkov (002-keycloak-module)
+- Consumer-managed external database; Kubernetes Secret-backed bootstrap credentials (002-keycloak-module)
 
 - Terraform ~> 1.3 + GitHub Actions, pre-commit, terraform-docs, tflint, (001-standardize-module-housekeeping)
 
@@ -22,6 +24,7 @@ tests/
 Terraform ~> 1.3: Follow standard conventions
 
 ## Recent Changes
+- 002-keycloak-module: Added Terraform ~> 1.3 + Helm provider, Kubernetes provider, GitHub Actions, pre-commit, terraform-docs, tflint, checkov
 
 - 001-standardize-module-housekeeping: Added Terraform ~> 1.3 + GitHub Actions, pre-commit, terraform-docs, tflint,
 

--- a/modules/keycloak/README.md
+++ b/modules/keycloak/README.md
@@ -1,0 +1,196 @@
+# keycloak
+
+This module deploys Keycloak through the `codecentric/keycloakx` Helm chart as
+an opinionated Terraform wrapper for the common deployment path: Keycloak on an
+existing Kubernetes cluster, backed by a consumer-managed external database,
+with optional ingress wiring for a consumer-managed ingress controller.
+
+The first version intentionally keeps the interface narrow:
+
+- no generic Helm values pass-through
+- no bundled in-module database path
+- no ingress controller, DNS, or certificate lifecycle ownership
+- existing Kubernetes Secret references are the preferred password source for
+  ongoing operations
+
+## Baseline usage
+
+```terraform
+module "keycloak" {
+  source = "dasmeta/shared/any//modules/keycloak"
+
+  hostname       = "keycloak.example.com"
+  admin_password = "change-me-admin-password"
+
+  database = {
+    host     = "postgresql.example.internal"
+    name     = "keycloak"
+    username = "keycloak"
+    password = "change-me-db-password"
+  }
+}
+```
+
+## Customization with existing Secrets
+
+```terraform
+module "keycloak" {
+  source = "dasmeta/shared/any//modules/keycloak"
+
+  hostname                   = "sso.example.com"
+  admin_password_secret_name = "keycloak-admin-password"
+
+  ingress = {
+    enabled            = true
+    ingress_class_name = "nginx"
+    annotations = {
+      "cert-manager.io/cluster-issuer" = "letsencrypt"
+    }
+    tls_secret_name = "keycloak-tls"
+  }
+
+  database = {
+    host                 = "postgresql.example.internal"
+    name                 = "keycloak"
+    username             = "keycloak"
+    password_secret_name = "keycloak-db-password"
+  }
+}
+```
+
+## Prerequisites
+
+- an existing Kubernetes cluster reachable through the Helm and Kubernetes providers
+- a consumer-managed external database supported by the upstream chart
+- a consumer-managed ingress controller when ingress is enabled
+- optional consumer-managed Kubernetes Secrets for admin and database passwords
+
+## Supported boundaries
+
+- Password sourcing is explicit: set raw password inputs or Secret references,
+  but not both for the same credential scope.
+- The module defaults Keycloak to `/` rather than the upstream `/auth` path to
+  keep the consumer-facing URL simpler.
+- Low-frequency upstream chart options remain out of scope until explicitly
+  approved as a wrapper expansion.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_secret_v1.admin_password](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_secret_v1.database_password](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_admin_password"></a> [admin\_password](#input\_admin\_password) | Raw admin password used only when the module manages the bootstrap secret. | `string` | `null` | no |
+| <a name="input_admin_password_secret_key"></a> [admin\_password\_secret\_key](#input\_admin\_password\_secret\_key) | The key inside the admin password Secret. | `string` | `"password"` | no |
+| <a name="input_admin_password_secret_name"></a> [admin\_password\_secret\_name](#input\_admin\_password\_secret\_name) | Existing Kubernetes Secret name that contains the Keycloak admin password. | `string` | `null` | no |
+| <a name="input_admin_username"></a> [admin\_username](#input\_admin\_username) | The initial Keycloak admin username. | `string` | `"admin"` | no |
+| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | The version of the codecentric/keycloakx Helm chart to deploy. | `string` | `"7.1.9"` | no |
+| <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Create the namespace if it does not already exist. | `bool` | `true` | no |
+| <a name="input_database"></a> [database](#input\_database) | The external database configuration for Keycloak. | <pre>object({<br/>    host                 = string<br/>    name                 = string<br/>    username             = string<br/>    vendor               = optional(string, "postgres")<br/>    port                 = optional(number, 5432)<br/>    password             = optional(string)<br/>    password_secret_name = optional(string)<br/>    password_secret_key  = optional(string, "password")<br/>  })</pre> | n/a | yes |
+| <a name="input_hostname"></a> [hostname](#input\_hostname) | The public hostname configured for Keycloak. | `string` | n/a | yes |
+| <a name="input_ingress"></a> [ingress](#input\_ingress) | Ingress configuration for the consumer-managed ingress path. | <pre>object({<br/>    enabled            = optional(bool, true)<br/>    ingress_class_name = optional(string)<br/>    annotations        = optional(map(string), {})<br/>    path               = optional(string, "/")<br/>    path_type          = optional(string, "Prefix")<br/>    tls_secret_name    = optional(string)<br/>  })</pre> | `{}` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the Helm release. | `string` | `"keycloak"` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | The Kubernetes namespace where Keycloak is deployed. | `string` | `"keycloak"` | no |
+| <a name="input_pod_labels"></a> [pod\_labels](#input\_pod\_labels) | Additional labels applied to the Keycloak pod. | `map(string)` | `{}` | no |
+| <a name="input_replicas"></a> [replicas](#input\_replicas) | The number of Keycloak replicas to run. | `number` | `1` | no |
+| <a name="input_resources"></a> [resources](#input\_resources) | CPU and memory resource requests and limits for Keycloak. | <pre>object({<br/>    limits   = optional(map(string), {})<br/>    requests = optional(map(string), {})<br/>  })</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_admin_password_secret_name"></a> [admin\_password\_secret\_name](#output\_admin\_password\_secret\_name) | The Kubernetes Secret name used for the admin password. |
+| <a name="output_database_password_secret_name"></a> [database\_password\_secret\_name](#output\_database\_password\_secret\_name) | The Kubernetes Secret name used for the database password. |
+| <a name="output_helm_metadata"></a> [helm\_metadata](#output\_helm\_metadata) | Helm release metadata for the deployed Keycloak release. |
+| <a name="output_ingress_hostnames"></a> [ingress\_hostnames](#output\_ingress\_hostnames) | Ingress hostnames configured for Keycloak. |
+| <a name="output_release_chart_version"></a> [release\_chart\_version](#output\_release\_chart\_version) | Chart version used for the Keycloak Helm release. |
+| <a name="output_release_name"></a> [release\_name](#output\_release\_name) | Name of the Keycloak Helm release. |
+| <a name="output_release_namespace"></a> [release\_namespace](#output\_release\_namespace) | Namespace of the Keycloak Helm release. |
+| <a name="output_release_status"></a> [release\_status](#output\_release\_status) | Status of the Keycloak Helm release. |
+<!-- END_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.17.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.38.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_secret_v1.admin_password](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_secret_v1.database_password](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_admin_password"></a> [admin\_password](#input\_admin\_password) | Raw admin password used only when the module manages the bootstrap secret. | `string` | `null` | no |
+| <a name="input_admin_password_secret_key"></a> [admin\_password\_secret\_key](#input\_admin\_password\_secret\_key) | The key inside the admin password Secret. | `string` | `"password"` | no |
+| <a name="input_admin_password_secret_name"></a> [admin\_password\_secret\_name](#input\_admin\_password\_secret\_name) | Existing Kubernetes Secret name that contains the Keycloak admin password. | `string` | `null` | no |
+| <a name="input_admin_username"></a> [admin\_username](#input\_admin\_username) | The initial Keycloak admin username. | `string` | `"admin"` | no |
+| <a name="input_chart_version"></a> [chart\_version](#input\_chart\_version) | The version of the codecentric/keycloakx Helm chart to deploy. | `string` | `"7.1.9"` | no |
+| <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | Create the namespace if it does not already exist. | `bool` | `true` | no |
+| <a name="input_database"></a> [database](#input\_database) | The external database configuration for Keycloak. | <pre>object({<br/>    host                 = string<br/>    name                 = string<br/>    username             = string<br/>    vendor               = optional(string, "postgres")<br/>    port                 = optional(number, 5432)<br/>    password             = optional(string)<br/>    password_secret_name = optional(string)<br/>    password_secret_key  = optional(string, "password")<br/>  })</pre> | n/a | yes |
+| <a name="input_hostname"></a> [hostname](#input\_hostname) | The public hostname configured for Keycloak. | `string` | n/a | yes |
+| <a name="input_ingress"></a> [ingress](#input\_ingress) | Ingress configuration for the consumer-managed ingress path. | <pre>object({<br/>    enabled            = optional(bool, true)<br/>    ingress_class_name = optional(string)<br/>    annotations        = optional(map(string), {})<br/>    path               = optional(string, "/")<br/>    path_type          = optional(string, "Prefix")<br/>    tls_secret_name    = optional(string)<br/>  })</pre> | `{}` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the Helm release. | `string` | `"keycloak"` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | The Kubernetes namespace where Keycloak is deployed. | `string` | `"keycloak"` | no |
+| <a name="input_pod_labels"></a> [pod\_labels](#input\_pod\_labels) | Additional labels applied to the Keycloak pod. | `map(string)` | `{}` | no |
+| <a name="input_replicas"></a> [replicas](#input\_replicas) | The number of Keycloak replicas to run. | `number` | `1` | no |
+| <a name="input_resources"></a> [resources](#input\_resources) | CPU and memory resource requests and limits for Keycloak. | <pre>object({<br/>    limits   = optional(map(string), {})<br/>    requests = optional(map(string), {})<br/>  })</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_admin_password_secret_name"></a> [admin\_password\_secret\_name](#output\_admin\_password\_secret\_name) | The Kubernetes Secret name used for the admin password. |
+| <a name="output_database_password_secret_name"></a> [database\_password\_secret\_name](#output\_database\_password\_secret\_name) | The Kubernetes Secret name used for the database password. |
+| <a name="output_helm_metadata"></a> [helm\_metadata](#output\_helm\_metadata) | Helm release metadata for the deployed Keycloak release. |
+| <a name="output_ingress_hostnames"></a> [ingress\_hostnames](#output\_ingress\_hostnames) | Ingress hostnames configured for Keycloak. |
+| <a name="output_release_chart_version"></a> [release\_chart\_version](#output\_release\_chart\_version) | Chart version used for the Keycloak Helm release. |
+| <a name="output_release_name"></a> [release\_name](#output\_release\_name) | Name of the Keycloak Helm release. |
+| <a name="output_release_namespace"></a> [release\_namespace](#output\_release\_namespace) | Namespace of the Keycloak Helm release. |
+| <a name="output_release_status"></a> [release\_status](#output\_release\_status) | Status of the Keycloak Helm release. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/keycloak/examples/basic/0-setup.tf
+++ b/modules/keycloak/examples/basic/0-setup.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = "~> 1.3"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "helm" {}
+
+provider "kubernetes" {}

--- a/modules/keycloak/examples/basic/1-example.tf
+++ b/modules/keycloak/examples/basic/1-example.tf
@@ -1,0 +1,40 @@
+module "keycloak" {
+  source = "../.."
+
+  name           = "keycloak"
+  namespace      = "keycloak"
+  hostname       = "keycloak.example.com"
+  admin_password = "change-me-admin-password"
+
+  database = {
+    host     = "postgresql.example.internal"
+    name     = "keycloak"
+    username = "keycloak"
+    password = "change-me-db-password"
+  }
+}
+
+module "keycloak_existing_secrets" {
+  source = "../.."
+
+  name                       = "keycloak-existing-secrets"
+  namespace                  = "keycloak"
+  hostname                   = "sso.example.com"
+  admin_password_secret_name = "keycloak-admin-password"
+
+  ingress = {
+    enabled            = true
+    ingress_class_name = "nginx"
+    annotations = {
+      "cert-manager.io/cluster-issuer" = "letsencrypt"
+    }
+    tls_secret_name = "keycloak-tls"
+  }
+
+  database = {
+    host                 = "postgresql.example.internal"
+    name                 = "keycloak"
+    username             = "keycloak"
+    password_secret_name = "keycloak-db-password"
+  }
+}

--- a/modules/keycloak/examples/basic/1-example.tf
+++ b/modules/keycloak/examples/basic/1-example.tf
@@ -1,40 +1,153 @@
+# EKS + RDS. Ingress joins an existing ALB created by AWS Load Balancer Controller
+# (same alb.ingress.kubernetes.io/group.name as your other Ingresses).
+#
+# Before apply:
+# - Configure Kubernetes/Helm providers in 0-setup.tf (kubeconfig or aws_eks_* auth).
+# - Ensure RDS allows Postgres from your EKS network (security groups).
+#
+# Do not commit real passwords or real database endpoints in examples.
+# Prefer existing Secrets, or use a local `terraform.tfvars` (gitignored).
+
 module "keycloak" {
   source = "../.."
 
-  name           = "keycloak"
-  namespace      = "keycloak"
-  hostname       = "keycloak.example.com"
+  name      = "keycloak"
+  namespace = "keycloak"
+  # Use your real hostname here for ingress traffic.
+  # For local testing with `kubectl port-forward`, you can use "localhost" and keep hostname_strict=false.
+  hostname        = "localhost"
+  hostname_strict = false
+  admin_username  = "admin"
+  # Example-only placeholder. Use `admin_password_secret_name` in real setups.
   admin_password = "change-me-admin-password"
 
   database = {
+    # Example-only placeholder. Prefer `password_secret_name` in real setups.
     host     = "postgresql.example.internal"
+    port     = 5432
     name     = "keycloak"
     username = "keycloak"
     password = "change-me-db-password"
   }
-}
 
-module "keycloak_existing_secrets" {
-  source = "../.."
-
-  name                       = "keycloak-existing-secrets"
-  namespace                  = "keycloak"
-  hostname                   = "sso.example.com"
-  admin_password_secret_name = "keycloak-admin-password"
-
+  # Replace group.name with the same value as your existing Ingress (kubectl get ingress -A -o yaml | grep group.name).
   ingress = {
     enabled            = true
-    ingress_class_name = "nginx"
+    ingress_class_name = "alb"
     annotations = {
-      "cert-manager.io/cluster-issuer" = "letsencrypt"
+      # Must match the group.name used by your existing Ingress resources (AWS LBC).
+      "alb.ingress.kubernetes.io/group.name"  = "my-existing-alb-group"
+      "alb.ingress.kubernetes.io/target-type" = "ip"
+      "alb.ingress.kubernetes.io/scheme"      = "internal"
+      # "alb.ingress.kubernetes.io/certificate-arn" = "arn:aws:acm:region:account:certificate/..."
+      # "alb.ingress.kubernetes.io/listen-ports"    = "[{\"HTTPS\":443}]"
+      # "alb.ingress.kubernetes.io/ssl-redirect"    = "443"
     }
-    tls_secret_name = "keycloak-tls"
+    # tls_secret_name = "keycloak-tls"
   }
 
-  database = {
-    host                 = "postgresql.example.internal"
-    name                 = "keycloak"
-    username             = "keycloak"
-    password_secret_name = "keycloak-db-password"
-  }
+  # --- If your ALB is NOT from AWS LBC (standalone ALB in AWS): use Service + target group instead ---
+  # ingress = { enabled = false }
+  # Then: kubectl get svc -n keycloak and register that Service with your ALB / TargetGroupBinding.
 }
+
+# Production-style alternative: reference existing Secrets (no raw passwords in Terraform).
+# Create Secrets `keycloak-admin-password` and `keycloak-db-password` in namespace `keycloak` first.
+#
+# module "keycloak" {
+#   source = "../.."
+#
+#   name                       = "keycloak"
+#   namespace                  = "keycloak"
+#   hostname                   = "keycloak.internal.example.com"
+#   admin_password_secret_name = "keycloak-admin-password"
+#
+#   database = {
+#     host                 = "mydb.xxxxxxxxxxxx.us-east-1.rds.amazonaws.com"
+#     name                 = "keycloak"
+#     username             = "keycloak"
+#     password_secret_name = "keycloak-db-password"
+#   }
+#
+#   ingress = {
+#     enabled            = true
+#     ingress_class_name = "alb"
+#     annotations = {
+#       "alb.ingress.kubernetes.io/group.name"  = "my-existing-alb-group"
+#       "alb.ingress.kubernetes.io/target-type" = "ip"
+#       "alb.ingress.kubernetes.io/scheme"      = "internal"
+#     }
+#   }
+# }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# module "keycloak" {
+#   source = "../.."
+
+#   name           = "keycloak"
+#   namespace      = "keycloak"
+#   hostname       = "keycloak.example.com"
+#   admin_password = "change-me-admin-password"
+
+#   database = {
+#     host     = "postgresql.example.internal"
+#     name     = "keycloak"
+#     username = "keycloak"
+#     password = "change-me-db-password"
+#   }
+# }
+
+# module "keycloak_existing_secrets" {
+#   source = "../.."
+
+#   name                       = "keycloak-existing-secrets"
+#   namespace                  = "keycloak"
+#   hostname                   = "sso.example.com"
+#   admin_password_secret_name = "keycloak-admin-password"
+
+#   ingress = {
+#     enabled            = true
+#     ingress_class_name = "nginx"
+#     annotations = {
+#       "cert-manager.io/cluster-issuer" = "letsencrypt"
+#     }
+#     tls_secret_name = "keycloak-tls"
+#   }
+
+#   database = {
+#     host                 = "postgresql.example.internal"
+#     name                 = "keycloak"
+#     username             = "keycloak"
+#     password_secret_name = "keycloak-db-password"
+#   }
+# }

--- a/modules/keycloak/examples/basic/README.md
+++ b/modules/keycloak/examples/basic/README.md
@@ -1,0 +1,80 @@
+# basic
+
+This example documents the baseline Keycloak deployment path for the module
+using raw password inputs that are converted into module-managed Kubernetes
+Secrets.
+
+Prerequisites:
+
+- an existing Kubernetes cluster reachable through the Helm and Kubernetes providers
+- a consumer-managed external PostgreSQL database
+- a consumer-managed ingress controller if `ingress.enabled` remains `true`
+
+The module keeps the interface intentionally narrow. It does not expose a
+generic Helm values pass-through, does not provision the database, and does not
+manage ingress controllers or certificate issuance.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_keycloak"></a> [keycloak](#module\_keycloak) | ../.. | n/a |
+| <a name="module_keycloak_existing_secrets"></a> [keycloak\_existing\_secrets](#module\_keycloak\_existing\_secrets) | ../.. | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_keycloak"></a> [keycloak](#module\_keycloak) | ../.. | n/a |
+| <a name="module_keycloak_existing_secrets"></a> [keycloak\_existing\_secrets](#module\_keycloak\_existing\_secrets) | ../.. | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/keycloak/main.tf
+++ b/modules/keycloak/main.tf
@@ -1,0 +1,152 @@
+locals {
+  admin_password_secret_name = var.admin_password_secret_name != null ? var.admin_password_secret_name : "${var.name}-admin-password"
+  admin_password_secret_key  = var.admin_password_secret_key
+
+  database_password_secret_name = try(var.database.password_secret_name, null) != null ? var.database.password_secret_name : "${var.name}-database-password"
+  database_password_secret_key  = try(var.database.password_secret_key, "password")
+
+  normalized_resources = merge(
+    length(try(var.resources.limits, {})) > 0 ? { limits = var.resources.limits } : {},
+    length(try(var.resources.requests, {})) > 0 ? { requests = var.resources.requests } : {}
+  )
+
+  ingress_enabled = try(var.ingress.enabled, true)
+  ingress_values = local.ingress_enabled ? {
+    enabled          = true
+    ingressClassName = try(var.ingress.ingress_class_name, null)
+    annotations      = try(var.ingress.annotations, {})
+    rules = [
+      {
+        host = var.hostname
+        paths = [
+          {
+            path     = try(var.ingress.path, "/")
+            pathType = try(var.ingress.path_type, "Prefix")
+          }
+        ]
+      }
+    ]
+    tls = try(var.ingress.tls_secret_name, null) != null ? [
+      {
+        hosts      = [var.hostname]
+        secretName = var.ingress.tls_secret_name
+      }
+    ] : []
+    } : {
+    enabled = false
+  }
+
+  values = merge(
+    {
+      replicas = var.replicas
+      http = {
+        relativePath = "/"
+      }
+      dbchecker = {
+        enabled = true
+      }
+      database = {
+        vendor            = try(var.database.vendor, "postgres")
+        hostname          = var.database.host
+        port              = try(var.database.port, 5432)
+        database          = var.database.name
+        username          = var.database.username
+        existingSecret    = local.database_password_secret_name
+        existingSecretKey = local.database_password_secret_key
+      }
+      proxy = {
+        enabled = true
+        mode    = "forwarded"
+        http = {
+          enabled = true
+        }
+      }
+      ingress = local.ingress_values
+      extraEnv = yamlencode([
+        {
+          name  = "KEYCLOAK_ADMIN"
+          value = var.admin_username
+        },
+        {
+          name = "KEYCLOAK_ADMIN_PASSWORD"
+          valueFrom = {
+            secretKeyRef = {
+              name = local.admin_password_secret_name
+              key  = local.admin_password_secret_key
+            }
+          }
+        },
+        {
+          name  = "KC_HOSTNAME"
+          value = var.hostname
+        }
+      ])
+    },
+    length(local.normalized_resources) > 0 ? { resources = local.normalized_resources } : {},
+    length(var.pod_labels) > 0 ? { podLabels = var.pod_labels } : {}
+  )
+}
+
+resource "kubernetes_secret_v1" "admin_password" {
+  count = var.admin_password != null ? 1 : 0
+
+  metadata {
+    name      = local.admin_password_secret_name
+    namespace = var.namespace
+  }
+
+  type = "Opaque"
+
+  data = {
+    (local.admin_password_secret_key) = var.admin_password
+  }
+}
+
+resource "kubernetes_secret_v1" "database_password" {
+  count = try(var.database.password, null) != null ? 1 : 0
+
+  metadata {
+    name      = local.database_password_secret_name
+    namespace = var.namespace
+  }
+
+  type = "Opaque"
+
+  data = {
+    (local.database_password_secret_key) = var.database.password
+  }
+}
+
+resource "helm_release" "this" {
+  depends_on = [
+    kubernetes_secret_v1.admin_password,
+    kubernetes_secret_v1.database_password,
+  ]
+
+  name             = var.name
+  repository       = "https://codecentric.github.io/helm-charts"
+  chart            = "keycloakx"
+  namespace        = var.namespace
+  version          = var.chart_version
+  create_namespace = var.create_namespace
+
+  atomic          = true
+  cleanup_on_fail = true
+  wait            = true
+
+  values = [
+    yamlencode(local.values),
+  ]
+
+  lifecycle {
+    precondition {
+      condition     = (var.admin_password != null) != (var.admin_password_secret_name != null)
+      error_message = "Set exactly one of admin_password or admin_password_secret_name."
+    }
+
+    precondition {
+      condition     = (try(var.database.password, null) != null) != (try(var.database.password_secret_name, null) != null)
+      error_message = "Set exactly one of database.password or database.password_secret_name."
+    }
+  }
+}

--- a/modules/keycloak/main.tf
+++ b/modules/keycloak/main.tf
@@ -33,8 +33,6 @@ locals {
       }
     ] : []
     } : {
-    # NOTE(change): Keep both sides of the conditional the same object shape.
-    # This avoids: "Inconsistent conditional result types".
     enabled          = false
     ingressClassName = null
     annotations      = {}
@@ -44,8 +42,6 @@ locals {
 
   values = merge(
     {
-      # NOTE(change): keycloakx chart only renders args when non-empty; otherwise the image may run
-      # `kc.sh` with no subcommand (prints help, exits 0). Force server startup.
       args = ["start"]
 
       replicas = var.replicas
@@ -91,7 +87,6 @@ locals {
           value = var.hostname
         },
         {
-          # NOTE(change): Allow kubectl port-forward / alternative Host headers without redirects.
           name  = "KC_HOSTNAME_STRICT"
           value = var.hostname_strict ? "true" : "false"
         }
@@ -103,8 +98,6 @@ locals {
 }
 
 resource "kubernetes_namespace_v1" "this" {
-  # NOTE(change): Helm's create_namespace happens at helm install time, but we create Secrets before
-  # the helm release. So we manage the namespace here to avoid "namespace not found" for Secrets.
   count = var.create_namespace ? 1 : 0
 
   metadata {
@@ -115,7 +108,6 @@ resource "kubernetes_namespace_v1" "this" {
 resource "kubernetes_secret_v1" "admin_password" {
   count = var.admin_password != null ? 1 : 0
 
-  # NOTE(change): Ensure namespace exists before Secret creation.
   depends_on = [kubernetes_namespace_v1.this]
 
   metadata {
@@ -133,7 +125,6 @@ resource "kubernetes_secret_v1" "admin_password" {
 resource "kubernetes_secret_v1" "database_password" {
   count = try(var.database.password, null) != null ? 1 : 0
 
-  # NOTE(change): Ensure namespace exists before Secret creation.
   depends_on = [kubernetes_namespace_v1.this]
 
   metadata {
@@ -155,20 +146,17 @@ resource "helm_release" "this" {
     kubernetes_secret_v1.database_password,
   ]
 
-  name       = var.name
-  repository = "https://codecentric.github.io/helm-charts"
-  chart      = "keycloakx"
-  namespace  = var.namespace
-  version    = var.chart_version
-  # NOTE(change): Namespace is created by kubernetes_namespace_v1 when create_namespace is true,
-  # otherwise it must already exist.
+  name             = var.name
+  repository       = "https://codecentric.github.io/helm-charts"
+  chart            = "keycloakx"
+  namespace        = var.namespace
+  version          = var.chart_version
   create_namespace = false
 
   atomic          = true
   cleanup_on_fail = true
   wait            = true
-  # NOTE(change): Keycloak can take longer than Helm provider default (300s) to become ready.
-  timeout = var.helm_timeout
+  timeout         = var.helm_timeout
 
   values = [
     yamlencode(local.values),

--- a/modules/keycloak/main.tf
+++ b/modules/keycloak/main.tf
@@ -33,11 +33,21 @@ locals {
       }
     ] : []
     } : {
-    enabled = false
+    # NOTE(change): Keep both sides of the conditional the same object shape.
+    # This avoids: "Inconsistent conditional result types".
+    enabled          = false
+    ingressClassName = null
+    annotations      = {}
+    rules            = []
+    tls              = []
   }
 
   values = merge(
     {
+      # NOTE(change): keycloakx chart only renders args when non-empty; otherwise the image may run
+      # `kc.sh` with no subcommand (prints help, exits 0). Force server startup.
+      args = ["start"]
+
       replicas = var.replicas
       http = {
         relativePath = "/"
@@ -79,6 +89,11 @@ locals {
         {
           name  = "KC_HOSTNAME"
           value = var.hostname
+        },
+        {
+          # NOTE(change): Allow kubectl port-forward / alternative Host headers without redirects.
+          name  = "KC_HOSTNAME_STRICT"
+          value = var.hostname_strict ? "true" : "false"
         }
       ])
     },
@@ -87,8 +102,21 @@ locals {
   )
 }
 
+resource "kubernetes_namespace_v1" "this" {
+  # NOTE(change): Helm's create_namespace happens at helm install time, but we create Secrets before
+  # the helm release. So we manage the namespace here to avoid "namespace not found" for Secrets.
+  count = var.create_namespace ? 1 : 0
+
+  metadata {
+    name = var.namespace
+  }
+}
+
 resource "kubernetes_secret_v1" "admin_password" {
   count = var.admin_password != null ? 1 : 0
+
+  # NOTE(change): Ensure namespace exists before Secret creation.
+  depends_on = [kubernetes_namespace_v1.this]
 
   metadata {
     name      = local.admin_password_secret_name
@@ -105,6 +133,9 @@ resource "kubernetes_secret_v1" "admin_password" {
 resource "kubernetes_secret_v1" "database_password" {
   count = try(var.database.password, null) != null ? 1 : 0
 
+  # NOTE(change): Ensure namespace exists before Secret creation.
+  depends_on = [kubernetes_namespace_v1.this]
+
   metadata {
     name      = local.database_password_secret_name
     namespace = var.namespace
@@ -119,20 +150,25 @@ resource "kubernetes_secret_v1" "database_password" {
 
 resource "helm_release" "this" {
   depends_on = [
+    kubernetes_namespace_v1.this,
     kubernetes_secret_v1.admin_password,
     kubernetes_secret_v1.database_password,
   ]
 
-  name             = var.name
-  repository       = "https://codecentric.github.io/helm-charts"
-  chart            = "keycloakx"
-  namespace        = var.namespace
-  version          = var.chart_version
-  create_namespace = var.create_namespace
+  name       = var.name
+  repository = "https://codecentric.github.io/helm-charts"
+  chart      = "keycloakx"
+  namespace  = var.namespace
+  version    = var.chart_version
+  # NOTE(change): Namespace is created by kubernetes_namespace_v1 when create_namespace is true,
+  # otherwise it must already exist.
+  create_namespace = false
 
   atomic          = true
   cleanup_on_fail = true
   wait            = true
+  # NOTE(change): Keycloak can take longer than Helm provider default (300s) to become ready.
+  timeout = var.helm_timeout
 
   values = [
     yamlencode(local.values),

--- a/modules/keycloak/outputs.tf
+++ b/modules/keycloak/outputs.tf
@@ -1,0 +1,39 @@
+output "release_name" {
+  value       = helm_release.this.name
+  description = "Name of the Keycloak Helm release."
+}
+
+output "release_namespace" {
+  value       = helm_release.this.namespace
+  description = "Namespace of the Keycloak Helm release."
+}
+
+output "release_status" {
+  value       = helm_release.this.status
+  description = "Status of the Keycloak Helm release."
+}
+
+output "release_chart_version" {
+  value       = helm_release.this.version
+  description = "Chart version used for the Keycloak Helm release."
+}
+
+output "helm_metadata" {
+  value       = helm_release.this.metadata
+  description = "Helm release metadata for the deployed Keycloak release."
+}
+
+output "admin_password_secret_name" {
+  value       = local.admin_password_secret_name
+  description = "The Kubernetes Secret name used for the admin password."
+}
+
+output "database_password_secret_name" {
+  value       = nonsensitive(local.database_password_secret_name)
+  description = "The Kubernetes Secret name used for the database password."
+}
+
+output "ingress_hostnames" {
+  value       = local.ingress_enabled ? [var.hostname] : []
+  description = "Ingress hostnames configured for Keycloak."
+}

--- a/modules/keycloak/tests/basic/README.md
+++ b/modules/keycloak/tests/basic/README.md
@@ -1,0 +1,72 @@
+# basic
+
+This test scenario covers both supported credential-source paths for the
+`keycloak` module:
+
+- raw passwords materialized into module-managed Secrets
+- consumer-managed existing Secret references
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_keycloak"></a> [keycloak](#module\_keycloak) | ../../ | n/a |
+| <a name="module_keycloak_existing_secrets"></a> [keycloak\_existing\_secrets](#module\_keycloak\_existing\_secrets) | ../../ | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_keycloak"></a> [keycloak](#module\_keycloak) | ../../ | n/a |
+| <a name="module_keycloak_existing_secrets"></a> [keycloak\_existing\_secrets](#module\_keycloak\_existing\_secrets) | ../../ | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/keycloak/tests/basic/main.tf
+++ b/modules/keycloak/tests/basic/main.tf
@@ -1,0 +1,40 @@
+module "keycloak" {
+  source = "../../"
+
+  name           = "keycloak"
+  namespace      = "keycloak"
+  hostname       = "keycloak.example.com"
+  admin_password = "change-me-admin-password"
+
+  database = {
+    host     = "postgresql.example.internal"
+    name     = "keycloak"
+    username = "keycloak"
+    password = "change-me-db-password"
+  }
+}
+
+module "keycloak_existing_secrets" {
+  source = "../../"
+
+  name                       = "keycloak-existing-secrets"
+  namespace                  = "keycloak"
+  hostname                   = "sso.example.com"
+  admin_password_secret_name = "keycloak-admin-password"
+
+  ingress = {
+    enabled            = true
+    ingress_class_name = "nginx"
+    annotations = {
+      "cert-manager.io/cluster-issuer" = "letsencrypt"
+    }
+    tls_secret_name = "keycloak-tls"
+  }
+
+  database = {
+    host                 = "postgresql.example.internal"
+    name                 = "keycloak"
+    username             = "keycloak"
+    password_secret_name = "keycloak-db-password"
+  }
+}

--- a/modules/keycloak/tests/basic/providers.tf
+++ b/modules/keycloak/tests/basic/providers.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = "~> 1.3"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "helm" {}
+
+provider "kubernetes" {}

--- a/modules/keycloak/variables.tf
+++ b/modules/keycloak/variables.tf
@@ -11,9 +11,11 @@ variable "namespace" {
 }
 
 variable "create_namespace" {
-  type        = bool
-  default     = true
-  description = "Create the namespace if it does not already exist."
+  type    = bool
+  default = true
+  # NOTE(change): Helm can create the namespace, but our bootstrap Secrets are applied before Helm.
+  # So this module can create the namespace via Kubernetes provider first.
+  description = "When true, create the target namespace with the Kubernetes provider before secrets and Helm (required so bootstrap Secrets can be applied)."
 }
 
 variable "chart_version" {
@@ -22,9 +24,24 @@ variable "chart_version" {
   description = "The version of the codecentric/keycloakx Helm chart to deploy."
 }
 
+variable "helm_timeout" {
+  type    = number
+  default = 900
+  # NOTE(change): Mitigates Helm "context deadline exceeded" for slow Keycloak startups.
+  description = "Seconds Helm waits for the release when wait is true. Keycloak startup often exceeds the provider default (300s), causing context deadline exceeded with atomic installs."
+}
+
 variable "hostname" {
   type        = string
   description = "The public hostname configured for Keycloak."
+}
+
+variable "hostname_strict" {
+  type    = bool
+  default = false
+  # NOTE(change): When false, you can access Keycloak via port-forward/localhost without being
+  # redirected to var.hostname.
+  description = "When false, sets KC_HOSTNAME_STRICT=false so Keycloak accepts any Host header (e.g. kubectl port-forward to 127.0.0.1 without redirects to hostname). Set true when public URLs must strictly match hostname."
 }
 
 variable "replicas" {

--- a/modules/keycloak/variables.tf
+++ b/modules/keycloak/variables.tf
@@ -11,10 +11,8 @@ variable "namespace" {
 }
 
 variable "create_namespace" {
-  type    = bool
-  default = true
-  # NOTE(change): Helm can create the namespace, but our bootstrap Secrets are applied before Helm.
-  # So this module can create the namespace via Kubernetes provider first.
+  type        = bool
+  default     = true
   description = "When true, create the target namespace with the Kubernetes provider before secrets and Helm (required so bootstrap Secrets can be applied)."
 }
 
@@ -25,9 +23,8 @@ variable "chart_version" {
 }
 
 variable "helm_timeout" {
-  type    = number
-  default = 900
-  # NOTE(change): Mitigates Helm "context deadline exceeded" for slow Keycloak startups.
+  type        = number
+  default     = 900
   description = "Seconds Helm waits for the release when wait is true. Keycloak startup often exceeds the provider default (300s), causing context deadline exceeded with atomic installs."
 }
 
@@ -37,10 +34,8 @@ variable "hostname" {
 }
 
 variable "hostname_strict" {
-  type    = bool
-  default = false
-  # NOTE(change): When false, you can access Keycloak via port-forward/localhost without being
-  # redirected to var.hostname.
+  type        = bool
+  default     = false
   description = "When false, sets KC_HOSTNAME_STRICT=false so Keycloak accepts any Host header (e.g. kubectl port-forward to 127.0.0.1 without redirects to hostname). Set true when public URLs must strictly match hostname."
 }
 

--- a/modules/keycloak/variables.tf
+++ b/modules/keycloak/variables.tf
@@ -1,0 +1,102 @@
+variable "name" {
+  type        = string
+  default     = "keycloak"
+  description = "The name of the Helm release."
+}
+
+variable "namespace" {
+  type        = string
+  default     = "keycloak"
+  description = "The Kubernetes namespace where Keycloak is deployed."
+}
+
+variable "create_namespace" {
+  type        = bool
+  default     = true
+  description = "Create the namespace if it does not already exist."
+}
+
+variable "chart_version" {
+  type        = string
+  default     = "7.1.9"
+  description = "The version of the codecentric/keycloakx Helm chart to deploy."
+}
+
+variable "hostname" {
+  type        = string
+  description = "The public hostname configured for Keycloak."
+}
+
+variable "replicas" {
+  type        = number
+  default     = 1
+  description = "The number of Keycloak replicas to run."
+}
+
+variable "admin_username" {
+  type        = string
+  default     = "admin"
+  description = "The initial Keycloak admin username."
+}
+
+variable "admin_password" {
+  type        = string
+  default     = null
+  description = "Raw admin password used only when the module manages the bootstrap secret."
+  sensitive   = true
+}
+
+variable "admin_password_secret_name" {
+  type        = string
+  default     = null
+  description = "Existing Kubernetes Secret name that contains the Keycloak admin password."
+}
+
+variable "admin_password_secret_key" {
+  type        = string
+  default     = "password"
+  description = "The key inside the admin password Secret."
+}
+
+variable "database" {
+  type = object({
+    host                 = string
+    name                 = string
+    username             = string
+    vendor               = optional(string, "postgres")
+    port                 = optional(number, 5432)
+    password             = optional(string)
+    password_secret_name = optional(string)
+    password_secret_key  = optional(string, "password")
+  })
+  description = "The external database configuration for Keycloak."
+  sensitive   = true
+}
+
+variable "ingress" {
+  type = object({
+    enabled            = optional(bool, true)
+    ingress_class_name = optional(string)
+    annotations        = optional(map(string), {})
+    path               = optional(string, "/")
+    path_type          = optional(string, "Prefix")
+    tls_secret_name    = optional(string)
+  })
+  default     = {}
+  description = "Ingress configuration for the consumer-managed ingress path."
+}
+
+variable "resources" {
+  type = object({
+    limits   = optional(map(string), {})
+    requests = optional(map(string), {})
+  })
+  default     = {}
+  description = "CPU and memory resource requests and limits for Keycloak."
+}
+
+variable "pod_labels" {
+  type        = map(string)
+  default     = {}
+  description = "Additional labels applied to the Keycloak pod."
+}

--- a/modules/keycloak/versions.tf
+++ b/modules/keycloak/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.3"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/specs/002-keycloak-module/checklists/requirements.md
+++ b/specs/002-keycloak-module/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Keycloak Helm Wrapper Module
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-26
+**Feature**: [spec.md](/Users/aram.karapetzan/Development/dasmeta/terraform/terraform-any-shared/specs/002-keycloak-module/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation completed in one pass. The spec keeps the module scoped to a new
+  curated Keycloak wrapper module, documents the upstream chart choice, and
+  leaves no unresolved clarification markers.
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/002-keycloak-module/contracts/keycloak-module-interface.md
+++ b/specs/002-keycloak-module/contracts/keycloak-module-interface.md
@@ -1,0 +1,62 @@
+# Contract: Keycloak Module Interface
+
+## Purpose
+
+Define the supported consumer-facing interface for `modules/keycloak` so the
+module remains an opinionated Keycloak wrapper instead of a broad chart
+pass-through.
+
+## Contract Fields
+
+The module contract MUST define:
+
+- `name`
+- `namespace`
+- `create_namespace`
+- `chart_version`
+- `hostname`
+- `ingress`
+- `bootstrap_credentials`
+- `external_database`
+- stable release-oriented outputs
+
+The contract MAY define:
+
+- a limited replica or resources configuration block
+- narrow metadata fields such as labels or annotations when they serve the
+  common Keycloak deployment path
+
+The contract MUST NOT define:
+
+- a generic Helm values pass-through
+- unrestricted `set`/`set_sensitive` style escape hatches exposed as public API
+- bundled database ownership in the first version
+- ingress controller, DNS, or certificate automation ownership
+
+## Contract Rules
+
+- The module MUST deploy Keycloak through the `codecentric/keycloakx` chart.
+- The module MUST support only the external-database deployment path in the
+  first maintained release.
+- Existing Kubernetes Secret references MUST be documented as the preferred
+  bootstrap credential path.
+- Raw bootstrap credential values MUST only be supported through an explicit
+  fallback path.
+- If both raw values and existing Secret references are configured for the same
+  credential scope, the module MUST fail validation.
+- README, example, and test assets MUST use only the supported contract surface
+  and MUST NOT rely on hidden chart internals.
+
+## Review Outcomes
+
+- `aligned`: the module exposes only the curated interface and its support
+  artifacts match it
+- `widened`: the module adds broad upstream exposure without recorded approval
+- `invalid`: the module violates prerequisite boundaries or has ambiguous
+  credential-source handling
+
+## Non-Goals
+
+- This contract does not promise support for the full upstream chart schema.
+- This contract does not cover advanced Keycloak topologies beyond the first
+  standard deployment path.

--- a/specs/002-keycloak-module/contracts/keycloak-validation-scope.md
+++ b/specs/002-keycloak-module/contracts/keycloak-validation-scope.md
@@ -1,0 +1,50 @@
+# Contract: Keycloak Validation Scope
+
+## Purpose
+
+Define the minimum validation and support-artifact scope required before
+`modules/keycloak` is treated as a maintained module in this repository.
+
+## Contract Fields
+
+Each validation record for the new module MUST identify:
+
+- `module_path`
+- `artifact_type`
+  one of `README`, `example`, `test`, `workflow-matrix`, `terraform-format`,
+  `terraform-validate`, or `pre-commit`
+- `status`
+  one of `required`, `covered`, `partial`, or `excluded`
+- `evidence_source`
+- `notes`
+
+## Contract Rules
+
+- `modules/keycloak/README.md` MUST include human-written module context plus
+  the terraform-docs generated block.
+- `modules/keycloak/examples/basic/` MUST provide one runnable supported usage
+  path for the curated interface.
+- `modules/keycloak/tests/basic/` MUST provide one Terraform validation path
+  that exercises the supported interface without relying on hidden inputs.
+- `modules/keycloak` MUST be added to the maintained-module matrices in
+  `.github/workflows/checkov.yaml` and `.github/workflows/tflint.yaml`.
+- `modules/keycloak` MUST be added to `.github/workflows/terraform-test.yaml`
+  unless implementation evidence proves the repository’s test harness cannot
+  support the module yet, in which case the exclusion must be documented before
+  merge.
+- Formatting and generated docs updates MUST be compatible with the current
+  `.pre-commit-config.yaml` baseline.
+
+## Review Outcomes
+
+- `covered`: README/example/test artifacts exist and workflow coverage is
+  aligned
+- `partial`: some validation exists but a required artifact or matrix entry is
+  still missing
+- `excluded`: a documented, reviewed exception explains why a required path is
+  absent
+
+## Non-Goals
+
+- This contract does not require live cluster integration testing.
+- This contract does not replace the module interface contract.

--- a/specs/002-keycloak-module/data-model.md
+++ b/specs/002-keycloak-module/data-model.md
@@ -1,0 +1,161 @@
+# Data Model: Keycloak Helm Wrapper Module
+
+## Entity: Keycloak Module Input Contract
+
+**Purpose**: Represents the curated Terraform interface exposed by
+`modules/keycloak` for the supported first-version deployment path.
+
+**Fields**:
+- `name`: Helm release name
+- `namespace`: Kubernetes namespace for the release
+- `create_namespace`: whether the namespace is created by Helm
+- `chart_version`: pinned upstream chart version chosen for the maintained
+  module baseline
+- `hostname`: primary Keycloak hostname
+- `replica_count`: desired number of Keycloak replicas when the chart supports
+  it in the curated path
+- `resources`: CPU and memory requests/limits for the main workload
+- `ingress`: structured ingress/application exposure settings used for a
+  consumer-managed ingress path
+- `bootstrap_credentials`: structured selection of existing-secret references
+  or raw values for supported admin/bootstrap credentials
+- `external_database`: structured connection settings for the required
+  consumer-managed external database
+- `extra_labels` or equivalent limited metadata fields: optional common-case
+  metadata supported by the wrapper
+
+**Relationships**:
+- One `Keycloak Module Input Contract` configures one `Keycloak Deployment
+  Baseline`
+- One `Keycloak Module Input Contract` includes one `Bootstrap Credential
+  Policy`
+- One `Keycloak Module Input Contract` includes one `External Database Config`
+- One `Keycloak Module Input Contract` may include one `Ingress Config`
+
+## Entity: Bootstrap Credential Policy
+
+**Purpose**: Defines how the module sources and validates Keycloak bootstrap or
+admin credentials.
+
+**Fields**:
+- `existing_secret_name`: name of a consumer-managed Kubernetes Secret when the
+  preferred reference path is used
+- `existing_secret_keys`: mapping of expected secret keys for the credential
+  fields the chart needs
+- `raw_values`: raw admin/bootstrap values supplied directly to Terraform when
+  the fallback path is used
+- `managed_secret_name`: name for the module-managed Secret created from raw
+  values when that fallback path is selected
+- `selection_mode`: `existing-secret` or `raw-values`
+- `conflict_rule`: validation error when both modes are configured for the same
+  credential scope
+
+**Relationships**:
+- One `Bootstrap Credential Policy` belongs to one `Keycloak Module Input
+  Contract`
+- One `Bootstrap Credential Policy` may produce one module-managed Kubernetes
+  Secret
+- One `Bootstrap Credential Policy` informs one `Module Output Contract`
+
+## Entity: External Database Config
+
+**Purpose**: Represents the required database connection details that remain
+consumer-managed but must be wired into the Keycloak release.
+
+**Fields**:
+- `host`
+- `port`
+- `database_name`
+- `username`
+- `credential_source`: existing secret reference or raw password value,
+  depending on the final curated interface
+- `ssl_mode` or equivalent minimal connection toggle if the chosen chart path
+  requires it
+
+**Relationships**:
+- One `External Database Config` belongs to one `Keycloak Module Input
+  Contract`
+- One `External Database Config` is referenced by one `Keycloak Deployment
+  Baseline`
+
+## Entity: Ingress Config
+
+**Purpose**: Captures the limited ingress-related settings that the module will
+support without taking ownership of ingress infrastructure.
+
+**Fields**:
+- `enabled`
+- `class_name`
+- `annotations`
+- `hostname`
+- `tls_secret_name`
+- `path_rules` if required by the selected chart path
+
+**Relationships**:
+- One `Ingress Config` belongs to one `Keycloak Module Input Contract`
+- One `Ingress Config` influences one `Keycloak Deployment Baseline`
+- One `Ingress Config` may be summarized in the `Module Output Contract`
+
+## Entity: Keycloak Deployment Baseline
+
+**Purpose**: Defines the supported default deployment shape the repository will
+stand behind for the first maintained release.
+
+**Fields**:
+- `upstream_chart`: fixed to `codecentric/keycloakx`
+- `deployment_mode`: `external-database`
+- `secret_strategy`: selected bootstrap credential mode
+- `ingress_boundary`: application configuration only; no ingress controller or
+  certificate issuance ownership
+- `unsupported_capabilities`: bundled database paths, broad values pass-through,
+  and other approval-gated advanced chart internals
+
+**Relationships**:
+- One `Keycloak Deployment Baseline` is configured by one `Keycloak Module
+  Input Contract`
+- One `Keycloak Deployment Baseline` is documented by the README, example, and
+  test artifacts
+
+## Entity: Module Output Contract
+
+**Purpose**: Describes the stable outputs returned to downstream consumers and
+operators after deployment.
+
+**Fields**:
+- `release_name`
+- `release_namespace`
+- `release_status`
+- `helm_metadata`
+- `chart_version`
+- `bootstrap_secret_name` when a stable Secret name is part of the supported
+  contract
+- `ingress_hostnames` when ingress is enabled
+
+**Relationships**:
+- One `Module Output Contract` is produced by one `Keycloak Deployment
+  Baseline`
+- One `Module Output Contract` is documented in README and validated by
+  example/test assets
+
+## State Transitions
+
+### Bootstrap Credential Selection Lifecycle
+
+- `unconfigured` -> `existing-secret`
+  when a valid existing Secret reference is supplied
+- `unconfigured` -> `raw-values`
+  when raw bootstrap values are supplied and no conflicting existing Secret
+  reference is set
+- `existing-secret` -> `invalid`
+  when raw values are also set for the same credential scope
+- `raw-values` -> `invalid`
+  when an existing Secret reference is also set for the same credential scope
+
+### Module Delivery Lifecycle
+
+- `planned` -> `implemented`
+  when the Terraform module files and curated interface are added
+- `implemented` -> `documented`
+  when README, example, and test artifacts match the final interface
+- `documented` -> `validated`
+  when formatting, validation, and workflow inclusion checks pass

--- a/specs/002-keycloak-module/plan.md
+++ b/specs/002-keycloak-module/plan.md
@@ -1,0 +1,250 @@
+# Implementation Plan: Keycloak Helm Wrapper Module
+
+**Branch**: `002-keycloak-module` | **Date**: 2026-03-26 | **Spec**: `/Users/aram.karapetzan/Development/dasmeta/terraform/terraform-any-shared/specs/002-keycloak-module/spec.md`
+**Input**: Feature specification from `/specs/002-keycloak-module/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Create a new opinionated Terraform module at `modules/keycloak` that deploys
+Keycloak through the `codecentric/keycloakx` Helm chart while keeping the
+consumer interface intentionally narrow. The module will target the standard
+deployment path only: Keycloak on Kubernetes with a consumer-managed external
+database, consumer-managed ingress controller and certificates, curated
+bootstrap secret handling, aligned documentation/examples/tests, and repository
+workflow coverage consistent with other maintained Helm-backed modules.
+
+## Technical Context
+
+**Terraform/OpenTofu Version**: Terraform `~> 1.3`, aligned with the
+repository baseline for maintained modules  
+**Providers / Upstream Modules**: `hashicorp/helm` for release management,
+`hashicorp/kubernetes` for optional managed Secret creation when raw bootstrap
+credentials are supplied, upstream baseline `codecentric/keycloakx` Helm chart  
+**Target Module Path**: `modules/keycloak`  
+**Examples / Tests in Scope**: `modules/keycloak/examples/basic/`,
+`modules/keycloak/tests/basic/`, and `modules/keycloak/README.md`  
+**Automation Gates**: `.pre-commit-config.yaml`,
+`.github/workflows/checkov.yaml`, `.github/workflows/tflint.yaml`,
+`.github/workflows/terraform-test.yaml`, and repo-wide `tfsec` coverage  
+**Target Platform**: Existing Kubernetes cluster with configured Helm/Kubernetes
+providers, consumer-managed external database, and consumer-managed ingress/TLS
+dependencies  
+**Constraints**: New module only; preserve opinionated wrapper boundary; no
+generic Helm values pass-through; first release supports external database
+mode only; ingress configuration is application-facing only and does not manage
+the ingress controller or certificates; existing secret references are the
+preferred credential path and mixed credential-source inputs must be rejected
+per credential scope  
+**Scale/Scope**: One new maintained module plus its README, examples, tests,
+version/provider declarations, and workflow matrix entries
+
+### Agent Context Compatibility
+
+**Language/Version**: Terraform ~> 1.3  
+**Primary Dependencies**: Helm provider, Kubernetes provider, GitHub Actions, pre-commit, terraform-docs, tflint, checkov  
+**Storage**: Consumer-managed external database; Kubernetes Secret-backed bootstrap credentials  
+**Project Type**: Terraform Helm wrapper module
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] Change stays within one coherent module responsibility and the current
+      repository scope.
+- [x] Consumer interface remains opinionated; any interface widening is
+      explicitly documented and approved.
+- [x] `README.md`, `examples/`, and `tests/` updates are listed for every
+      behavior or interface change.
+- [x] `versions.tf` or `version.tf` and `providers.tf` impacts are reviewed and
+      made explicit when compatibility changes.
+- [x] Breaking changes, weakened defaults, or standards conflicts are recorded
+      with approval status before implementation.
+
+Gate result before Phase 0: PASS. The feature introduces one new module within
+the existing repository boundary, wraps an upstream chart instead of rebuilding
+Keycloak from direct resources, and keeps interface widening explicitly out of
+scope for the first version.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-keycloak-module/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── keycloak-module-interface.md
+│   └── keycloak-validation-scope.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+modules/keycloak/
+├── main.tf
+├── variables.tf
+├── outputs.tf
+├── versions.tf
+├── README.md
+├── examples/
+│   └── basic/
+└── tests/
+    └── basic/
+
+.github/workflows/
+.pre-commit-config.yaml
+```
+
+**Structure Decision**: Implement Keycloak as a new maintained top-level Helm
+wrapper module with dedicated example and test scaffolding. Repository-level
+workflow files remain in scope because the new module must be added to the same
+maintained-module validation path used for comparable modules.
+
+## Phase 0 Research
+
+Research findings are captured in
+`/Users/aram.karapetzan/Development/dasmeta/terraform/terraform-any-shared/specs/002-keycloak-module/research.md`.
+All Technical Context decisions needed for planning are resolved; no
+`NEEDS CLARIFICATION` items remain.
+
+## Phase 1 Design Artifacts
+
+- Data model:
+  `/Users/aram.karapetzan/Development/dasmeta/terraform/terraform-any-shared/specs/002-keycloak-module/data-model.md`
+- Contracts:
+  `/Users/aram.karapetzan/Development/dasmeta/terraform/terraform-any-shared/specs/002-keycloak-module/contracts/keycloak-module-interface.md`
+  `/Users/aram.karapetzan/Development/dasmeta/terraform/terraform-any-shared/specs/002-keycloak-module/contracts/keycloak-validation-scope.md`
+- Quickstart:
+  `/Users/aram.karapetzan/Development/dasmeta/terraform/terraform-any-shared/specs/002-keycloak-module/quickstart.md`
+
+## Current State
+
+- Starting module path: `modules/keycloak` does not exist yet.
+- Comparable repository patterns exist in maintained Helm modules such as
+  `modules/defectdojo`, `modules/gitlab-runner`, `modules/horizon-monitor`, and
+  `modules/qdrant`.
+- Repository workflow matrices currently cover maintained modules explicitly via
+  path lists in `.github/workflows/checkov.yaml`,
+  `.github/workflows/tflint.yaml`, and `.github/workflows/terraform-test.yaml`.
+- `terraform-test` coverage expects module-local example or test scaffolding;
+  the new module can enter that workflow if `examples/basic` and/or
+  `tests/basic` are created with a runnable Terraform consumer path.
+
+## Comparison Against Internal Standards
+
+- Module design boundary: stays within one module responsibility, deploying
+  Keycloak only and leaving databases, ingress controllers, DNS, TLS, and
+  secret backends outside the module boundary.
+- Variable and output alignment: the module will expose only curated inputs for
+  the common Keycloak case and useful release outputs such as release identity,
+  status, chart version, and Helm metadata.
+- Documentation, examples, and tests alignment: README, `examples/basic`, and
+  `tests/basic` are first-class deliverables in this plan, not follow-up work.
+- Version and provider alignment: the module will declare Terraform/provider
+  compatibility explicitly in `versions.tf`; any added provider usage must be
+  justified by the final secret-handling design rather than inferred later.
+
+## New-Module Sourcing Assessment
+
+- Target platform: Kubernetes application deployment through Helm
+- Provider collection checked: repository-local Helm wrapper patterns and
+  maintained-module validation expectations
+- Candidate upstream modules considered: `codecentric/keycloakx` Helm chart
+- Selected upstream wrapper baseline: `codecentric/keycloakx`
+- Why this is the closest scope match: it matches the requested delivery model,
+  keeps release management inside Helm, and avoids re-implementing Keycloak
+  deployment logic from lower-level Kubernetes resources
+- Wrapper-added usability or interface improvements: curated Terraform inputs,
+  explicit external-dependency boundaries, deterministic bootstrap credential
+  handling, repository-aligned outputs, and maintained-module docs/examples/tests
+- Fallback required: No
+- Fallback reason: the selected upstream chart is already the requested baseline
+
+## Comparison Against Scratch Template
+
+- Use this section only when new-module creation falls back to direct
+  resource-based scaffolding.
+- Relevant upstream patterns: N/A
+- Patterns intentionally not copied: N/A
+
+## Proposed File Changes
+
+- Files to create:
+  `modules/keycloak/main.tf`,
+  `modules/keycloak/variables.tf`,
+  `modules/keycloak/outputs.tf`,
+  `modules/keycloak/versions.tf`,
+  `modules/keycloak/README.md`,
+  `modules/keycloak/examples/basic/*`,
+  `modules/keycloak/tests/basic/*`
+- Files to update:
+  `.github/workflows/checkov.yaml`,
+  `.github/workflows/tflint.yaml`,
+  `.github/workflows/terraform-test.yaml`,
+  `.pre-commit-config.yaml` only if the new module requires repository-level
+  doc-generation or formatting scope changes beyond current defaults
+- Files to leave unchanged:
+  unrelated modules, repository support-only paths, and any workflow scopes not
+  needed to validate the new Keycloak module
+
+## Risks and Approvals
+
+- Potential breaking changes:
+  none expected because this is a new module; workflow updates must avoid
+  regressing existing matrices
+- Potential interface-widening changes:
+  adding a generic `values`, `custom_values`, or similar pass-through input;
+  exposing low-frequency chart internals; making bundled database or ingress
+  controller ownership part of the first version
+- Conflicts requiring approval:
+  any proposal to broaden the interface beyond curated inputs, skip maintained
+  module validation inclusion, or choose a direct-resource implementation over
+  the chart wrapper baseline
+- Fallback sources needed:
+  none beyond the repository constitution, existing maintained Helm modules,
+  and the feature spec
+
+## Execution Notes
+
+- Recommended order of edits:
+  1. Scaffold `modules/keycloak` with explicit versions/providers and a narrow
+     variable surface.
+  2. Implement Helm values assembly and bootstrap-credential source selection.
+  3. Add outputs, README narrative, and terraform-docs block.
+  4. Add `examples/basic` and `tests/basic` consumer paths.
+  5. Add workflow matrix entries for the new maintained module.
+  6. Run formatting and validation, then reconcile generated docs.
+- Validation after edits:
+  `terraform fmt -check -recursive modules/keycloak`,
+  `terraform -chdir=modules/keycloak init -backend=false`,
+  `terraform -chdir=modules/keycloak validate`,
+  `terraform -chdir=modules/keycloak/examples/basic init -backend=false`,
+  `terraform -chdir=modules/keycloak/examples/basic validate`,
+  `terraform -chdir=modules/keycloak/tests/basic init -backend=false`,
+  `terraform -chdir=modules/keycloak/tests/basic validate`,
+  `PRE_COMMIT_HOME=/tmp/pre-commit-cache python3 -m pre_commit run --all-files`
+
+## Post-Design Constitution Check
+
+- [x] Change remains within one coherent Keycloak module responsibility and the
+      current repository scope.
+- [x] The wrapper interface stays opinionated and intentionally excludes broad
+      upstream pass-through inputs.
+- [x] README, example, and test work are explicitly part of the planned edit
+      surface.
+- [x] Version/provider impacts are explicit because the plan names `versions.tf`
+      and the Helm/Kubernetes provider decision.
+- [x] No breaking changes are planned; approval-gated interface widening and
+      standards conflicts are explicitly called out.
+
+Gate result after Phase 1: PASS.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**

--- a/specs/002-keycloak-module/quickstart.md
+++ b/specs/002-keycloak-module/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart: Keycloak Helm Wrapper Module
+
+## Goal
+
+Implement `modules/keycloak` as a maintained Terraform Helm wrapper for the
+standard Keycloak deployment path: external database, curated ingress support,
+explicit bootstrap credential handling, and repository-aligned validation.
+
+## Prerequisites
+
+- Work from branch `002-keycloak-module`
+- Review:
+  - `spec.md`
+  - `plan.md`
+  - `research.md`
+  - `data-model.md`
+  - `contracts/keycloak-module-interface.md`
+  - `contracts/keycloak-validation-scope.md`
+- Have a reachable Kubernetes context available if you intend to run Helm-based
+  example flows beyond static validation
+
+## Execution Steps
+
+1. Scaffold the module
+   - create `modules/keycloak/main.tf`, `variables.tf`, `outputs.tf`,
+     `versions.tf`, and `README.md`
+   - pin Terraform and provider compatibility explicitly
+   - establish the `codecentric/keycloakx` chart as the only upstream baseline
+
+2. Implement the curated interface
+   - add release identity, namespace, hostname/ingress, external database, and
+     bootstrap credential inputs
+   - reject broad values pass-through inputs
+   - implement secret-source selection so existing Secret references are the
+     preferred path and conflicting input modes fail validation
+
+3. Add support artifacts
+   - create `modules/keycloak/examples/basic/` for one supported deployment
+     path
+   - create `modules/keycloak/tests/basic/` for one Terraform validation path
+   - document prerequisites and unsupported capabilities in `README.md`
+
+4. Align repository validation
+   - add `modules/keycloak` to `checkov`, `tflint`, and `terraform-test`
+     workflow matrices
+   - regenerate terraform-docs content and reconcile any pre-commit changes
+
+## Validation Commands
+
+Run these after implementation:
+
+```bash
+terraform fmt -check -recursive modules/keycloak
+terraform -chdir=modules/keycloak init -backend=false
+terraform -chdir=modules/keycloak validate
+terraform -chdir=modules/keycloak/examples/basic init -backend=false
+terraform -chdir=modules/keycloak/examples/basic validate
+terraform -chdir=modules/keycloak/tests/basic init -backend=false
+terraform -chdir=modules/keycloak/tests/basic validate
+PRE_COMMIT_HOME=/tmp/pre-commit-cache python3 -m pre_commit run --all-files
+git diff -- modules/keycloak .github/workflows .pre-commit-config.yaml AGENTS.md
+```
+
+If `pre-commit` rewrites README content or formatting, rerun it until the tree
+stabilizes.
+
+## Expected Review Outcome
+
+- Reviewers can identify the supported deployment path and required inputs from
+  the README and basic example without reading module internals
+- The module stays within a curated wrapper boundary and does not expose the
+  full upstream chart surface
+- Workflow coverage treats `modules/keycloak` as a maintained module
+- Validation makes conflicting bootstrap credential configurations explicit

--- a/specs/002-keycloak-module/research.md
+++ b/specs/002-keycloak-module/research.md
@@ -1,0 +1,121 @@
+# Phase 0 Research: Keycloak Helm Wrapper Module
+
+## Decision 1: Use the `codecentric/keycloakx` Helm chart as the only deployment baseline
+
+**Decision**: Build the new module as an opinionated wrapper around the
+`codecentric/keycloakx` Helm chart and do not plan a direct Kubernetes-resource
+implementation path for the first version.
+
+**Rationale**: The feature spec explicitly names `codecentric/keycloakx` as the
+upstream baseline, and the repository constitution prefers wrapping a
+provider-maintained chart before recreating equivalent behavior directly. This
+keeps the module aligned with existing Helm-wrapper patterns in the repository.
+
+**Alternatives considered**:
+- Deploy Keycloak from raw Kubernetes resources:
+  rejected because it would ignore the requested upstream baseline and create a
+  larger maintenance surface.
+- Introduce a dual-mode chart-or-resources implementation:
+  rejected because it would widen scope without solving a current requirement.
+
+## Decision 2: Keep the first-version interface curated and task-oriented
+
+**Decision**: Expose only first-class inputs that map to the common Keycloak
+deployment path: release identity, namespace handling, chart version pinning,
+replica/resources basics, hostname and ingress settings, bootstrap credential
+selection, and external database connectivity. Do not include a generic Helm
+values pass-through.
+
+**Rationale**: The spec and constitution both require an opinionated wrapper
+instead of a broad chart mirror. A narrow interface keeps the module reviewable
+and avoids turning `modules/keycloak` into another place consumers must learn
+the full upstream values schema.
+
+**Alternatives considered**:
+- Expose `values`, `custom_values`, or `set` escape hatches:
+  rejected because they undermine the wrapper boundary in the first release.
+- Mirror most upstream chart options as Terraform variables:
+  rejected because it increases maintenance cost without improving the common
+  deployment path.
+
+## Decision 3: Treat external database, ingress controller, DNS, TLS, and secret backends as prerequisites
+
+**Decision**: The first version will support only consumer-managed external
+database connectivity and application-facing ingress/hostname configuration.
+The module will not provision the database, ingress controller, DNS records,
+certificate issuance, or an external secret backend.
+
+**Rationale**: This matches the clarified feature scope and keeps the module
+inside one coherent responsibility boundary: deploying the Keycloak workload
+through Helm. It also aligns with how other repository modules assume an
+already-available Kubernetes environment and adjacent platform services.
+
+**Alternatives considered**:
+- Add bundled database support:
+  rejected because the clarified spec explicitly excludes it from the first
+  supported mode.
+- Manage ingress controller or certificate resources:
+  rejected because that would cross the module boundary into adjacent platform
+  infrastructure.
+
+## Decision 4: Prefer consumer-managed secret references, with a controlled raw-value fallback
+
+**Decision**: Support two bootstrap-credential paths:
+1. preferred path: consumer-managed existing Kubernetes Secret references
+2. fallback path: raw secret values supplied to the module and materialized into
+   a module-managed Kubernetes Secret only when no existing secret reference is
+   configured for that credential scope
+
+If both paths are configured for the same credential scope, the module should
+fail validation rather than silently mixing sources.
+
+**Rationale**: Existing secret references are safer for ongoing operations and
+fit better with real platform ownership boundaries. Raw values still provide a
+supported bootstrap path for simpler environments, but keeping that path behind
+explicit selection avoids ambiguity and hidden precedence rules.
+
+**Alternatives considered**:
+- Support only raw values:
+  rejected because the spec explicitly requires existing secret references too.
+- Support only existing secret references:
+  rejected because the spec explicitly requires a raw-value path too.
+- Silently prefer one source when both are set:
+  rejected because it makes conflicting input harder to review and debug.
+
+## Decision 5: Include the new module in maintained-module workflow matrices
+
+**Decision**: Plan workflow updates so `modules/keycloak` is added to
+`.github/workflows/checkov.yaml`, `.github/workflows/tflint.yaml`, and
+`.github/workflows/terraform-test.yaml`, assuming the implementation delivers
+the planned example/test scaffolding.
+
+**Rationale**: The feature spec treats documentation and validation as part of
+the deliverable. The repository’s housekeeping docs already define maintained
+module workflow coverage as part of the review baseline for comparable modules.
+
+**Alternatives considered**:
+- Defer workflow inclusion until a later follow-up:
+  rejected because it would leave the new maintained module below the stated
+  quality bar at the moment it is introduced.
+- Add only static checks and skip `terraform-test`:
+  rejected because the module scope already includes runnable example/test
+  paths and the spec expects them.
+
+## Decision 6: Expose release-oriented outputs instead of deep runtime internals
+
+**Decision**: The first version should output release metadata that helps
+downstream consumers and operators identify what was deployed, such as release
+name, namespace, chart version or Helm metadata, deployment status, and any
+selected bootstrap Secret name or ingress host data that remains stable and
+useful.
+
+**Rationale**: The spec asks for useful outputs while the constitution cautions
+against widening the interface. Release-oriented outputs are consistent with
+other maintained Helm modules and avoid exposing unstable chart internals as
+module API.
+
+**Alternatives considered**:
+- No outputs:
+  rejected because the spec explicitly requires useful downstream outputs.
+- Expose broad rendered chart internals:
+  rejected because that would create unnecessary interface surface area.

--- a/specs/002-keycloak-module/spec.md
+++ b/specs/002-keycloak-module/spec.md
@@ -1,0 +1,258 @@
+# Feature Specification: Keycloak Helm Wrapper Module
+
+**Feature Branch**: `002-keycloak-module`  
+**Created**: 2026-03-26  
+**Status**: Draft  
+**Input**: User description: "implement new terraform module using module developer skill for keycloak using codecentric/keycloakx helm chart similar to other modules that are about helm in this repo"
+
+## Module Context *(mandatory)*
+
+- **Target Module Path**: `modules/keycloak`
+- **Related Files In Scope**: `modules/keycloak/main.tf`,
+  `modules/keycloak/variables.tf`, `modules/keycloak/outputs.tf`,
+  `modules/keycloak/versions.tf`, `modules/keycloak/README.md`,
+  `modules/keycloak/examples/basic/`, `modules/keycloak/tests/basic/`,
+  `.github/workflows/terraform-test.yaml`, `.github/workflows/tflint.yaml`,
+  `.github/workflows/checkov.yaml`, and `.pre-commit-config.yaml`
+- **Upstream Baseline**: `codecentric/keycloakx` Helm chart
+- **Requested Interface Change**: Add a new opinionated Terraform module that
+  deploys Keycloak through a narrow, consumer-friendly interface with documented
+  defaults, limited override points, and useful release outputs
+- **Breaking Change / Interface Widening**: None. This is a new module. The
+  spec assumes the module will avoid exposing the full upstream chart surface
+  unless later approval is recorded
+
+## Clarifications
+
+### Session 2026-03-26
+
+- Q: What is the intended first-version ownership boundary for adjacent
+  dependencies? → A: Keycloak-only wrapper; consumers provide adjacent
+  dependencies outside the module
+- Q: Which database mode should the first supported version target? → A:
+  Require an external database in the supported first version
+- Q: How should ingress be handled in the first version? → A: Support
+  Keycloak hostname and ingress configuration, but require consumers to manage
+  the ingress controller and certificate issuance outside the module
+- Q: How broad should the first-version input surface be? → A: Only curated
+  first-class inputs; no generic Helm-values pass-through in the first version
+- Q: How should admin/bootstrap secrets be handled in the first version? → A:
+  Support both raw secret values and consumer-managed secret references
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Deploy a Standard Keycloak Release (Priority: P1)
+
+As a platform engineer, I want a dedicated Keycloak module that matches the
+repository's Helm-wrapper style so I can deploy a standard Keycloak instance
+without building a custom Helm release from scratch.
+
+**Why this priority**: The repository currently lacks a Keycloak module. A
+working baseline deployment is the smallest valuable outcome and unlocks all
+later documentation and validation work.
+
+**Independent Test**: Can be fully tested by using the documented basic example
+for `modules/keycloak` and confirming it represents one complete, supported
+deployment path for a standard Keycloak release.
+
+**Acceptance Scenarios**:
+
+1. **Given** a consumer needs a standard Keycloak deployment, **When** they
+   open the new module README and basic example, **Then** they can identify the
+   required inputs, defaults, and expected deployment shape without reading the
+   module internals.
+2. **Given** the module is used with the documented baseline inputs, **When**
+   the consumer follows the example, **Then** the module behaves as a curated
+   Keycloak deployment wrapper rather than a raw chart pass-through.
+
+---
+
+### User Story 2 - Customize the Common Keycloak Use Case (Priority: P2)
+
+As a platform engineer, I want the module to expose the common settings teams
+actually change so I can adapt Keycloak deployments without needing the full
+upstream chart interface.
+
+**Why this priority**: The module only stays valuable if it balances sensible
+defaults with the most common customization points. That is the repository's
+wrapper standard for Helm-backed modules.
+
+**Independent Test**: Can be fully tested by reviewing the supported input
+surface and confirming it documents at least one default deployment path and
+one customization path without requiring unsupported chart internals.
+
+**Acceptance Scenarios**:
+
+1. **Given** a consumer needs to adjust common deployment settings, **When**
+   they review the supported inputs, **Then** they can find documented knobs
+   for the common case without being presented with the entire upstream values
+   surface.
+2. **Given** a consumer requests a low-frequency upstream option, **When** the
+   module scope is reviewed, **Then** unsupported pass-through expansion is
+   either intentionally excluded or documented as approval-gated.
+
+---
+
+### User Story 3 - Trust the Module Through Documentation and Validation (Priority: P3)
+
+As a repository maintainer, I want the new Keycloak module to include aligned
+docs, examples, tests, and validation scope so the module can be reviewed and
+adopted like the other maintained Helm modules in this repository.
+
+**Why this priority**: A shared module is not complete until the repository can
+verify and explain it consistently. Documentation and validation are part of
+the deliverable, not follow-up work.
+
+**Independent Test**: Can be fully tested by reviewing the module README,
+example, test coverage, and affected automation files to confirm the module is
+included in the same repository quality gates used for comparable maintained
+modules.
+
+**Acceptance Scenarios**:
+
+1. **Given** a maintainer reviews the new module, **When** they inspect the
+   README, example, and test assets, **Then** the supported usage is clear and
+   aligned across all three.
+2. **Given** the repository runs its standard validation flow, **When** the new
+   module is included, **Then** the module participates in the relevant checks
+   or has any exception documented explicitly.
+
+### Edge Cases
+
+- What happens when the desired Keycloak deployment depends on prerequisites
+  outside this module, such as databases, ingress, or secrets that the module
+  does not own?
+- What happens when a consumer tries to rely on a bundled or in-module database
+  path that the first version intentionally excludes?
+- What happens when a consumer expects the module to provision ingress
+  controllers or certificate automation that the first version intentionally
+  leaves external?
+- What happens when a consumer provides both raw secret values and existing
+  secret references for the same bootstrap credential path?
+- How does the module behave when consumers need an upstream chart option that
+  is outside the repository's supported common-case interface?
+- What happens if Helm, Terraform, or chart compatibility expectations differ
+  from the versions already used by comparable maintained modules?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The feature MUST create a new module at `modules/keycloak` that
+  owns one coherent responsibility: deploying Keycloak as an opinionated
+  Helm-backed application module.
+- **FR-002**: The module MUST follow the repository's Helm-wrapper pattern by
+  exposing a narrow set of consumer inputs for the common Keycloak deployment
+  case instead of mirroring the full upstream chart interface.
+- **FR-002a**: The first version MUST expose only curated, first-class
+  consumer inputs and MUST NOT include a generic Helm-values pass-through or
+  equivalent implicit escape hatch.
+- **FR-003**: The module MUST define documented defaults and clearly separated
+  consumer override points so users can distinguish supported baseline behavior
+  from optional customization.
+- **FR-003a**: The first version MUST define one documented and deterministic
+  rule for how bootstrap or admin credentials are sourced when both direct
+  secret values and consumer-managed secret references are supported.
+- **FR-004**: The module MUST document any required external prerequisites that
+  remain outside the module boundary, including cases where Keycloak depends on
+  surrounding infrastructure the module does not provision.
+- **FR-004a**: The first version MUST treat databases, ingress controllers,
+  DNS, TLS assets, and secret backends as consumer-managed prerequisites rather
+  than module-owned infrastructure.
+- **FR-004b**: The first supported deployment mode MUST assume Keycloak
+  connects to a consumer-managed external database rather than a bundled
+  in-module database path.
+- **FR-004c**: The first version MUST support hostname and ingress-related
+  application configuration only to the extent needed for a consumer-managed
+  ingress path and MUST NOT assume ownership of ingress controllers or
+  certificate issuance.
+- **FR-005**: The module MUST provide useful outputs for downstream consumers
+  and operators to identify the deployed release and its resulting metadata.
+- **FR-005a**: The module MUST support bootstrap credential input through both
+  direct values and consumer-managed secret references in the first version,
+  with clear documentation for the supported paths and precedence rules.
+- **FR-006**: The module MUST include a `README.md`, at least one example, and
+  at least one test path that align with the final supported module interface.
+- **FR-007**: The module MUST keep Terraform and provider compatibility
+  expectations explicit in the files that define version support.
+- **FR-008**: Repository validation configuration MUST include the new module in
+  the relevant documented quality gates or record any justified exclusion.
+- **FR-009**: The spec, plan, and implementation MUST record that the
+  `codecentric/keycloakx` chart was chosen as the upstream baseline for this
+  module instead of direct resource-based deployment.
+- **FR-010**: Any later proposal to expose broad upstream values, weaken
+  defaults, or widen the interface beyond the common case MUST be treated as an
+  approval-gated change.
+
+### Compatibility & Delivery Requirements
+
+- **CDR-001**: The spec MUST identify the new target module path and all
+  related example, test, and automation files expected to be added or updated.
+- **CDR-002**: The feature MUST preserve repository consistency with comparable
+  maintained Helm modules in naming, documentation shape, and validation
+  expectations.
+- **CDR-003**: The implementation plan MUST name the validation steps that prove
+  the new module is safe to add to the maintained module set.
+- **CDR-004**: If the new module leaves advanced Keycloak capabilities out of
+  scope, the documentation MUST explain those boundaries in plain language.
+
+### Key Entities *(include if feature involves data or structured configuration)*
+
+- **Keycloak Module Input Contract**: The supported set of consumer-facing
+  inputs that describe release identity, namespace handling, version selection,
+  common configuration defaults, and limited override behavior.
+- **Keycloak Deployment Baseline**: The repository-approved default deployment
+  shape for a standard Keycloak installation using the selected upstream chart.
+- **Module Output Contract**: The documented release metadata and deployment
+  details returned to downstream consumers after applying the module.
+
+### Assumptions
+
+- The new module path will be `modules/keycloak`, not `modules/keycloakx`,
+  because repository modules present curated consumer capabilities rather than
+  upstream chart names directly.
+- The first supported use case is a standard in-cluster Keycloak deployment.
+  Provisioning adjacent infrastructure such as external databases, ingress
+  controllers, or secret backends remains outside this module unless explicitly
+  included later.
+- The first version will not provision or own databases, ingress, DNS, TLS, or
+  secret backends. Consumers must connect those dependencies separately.
+- The first supported persistence model is an external database supplied by the
+  consumer environment.
+- The first version may configure Keycloak for consumer-managed ingress and
+  hostname use, but it will not own the ingress controller or certificate
+  lifecycle.
+- The first version may support both direct bootstrap secret inputs and
+  consumer-managed secret references, provided the interface stays explicit and
+  the precedence between the two paths is documented.
+- The module will follow the same maintenance expectations as other Helm-based
+  modules already kept in the repository, including README context,
+  example/test coverage, and repository automation updates where relevant.
+- The first version favors an intuitive, explicit interface over generic
+  flexibility. Missing capabilities can be added later through reviewed module
+  changes instead of broad pass-through inputs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A reviewer can identify the Keycloak module path, one supported
+  deployment path, and the required consumer inputs from the module README and
+  basic example within 5 minutes without reading module source files.
+- **SC-002**: The feature delivers at least one documented default deployment
+  path and at least one documented customization path that stay within the
+  supported wrapper interface.
+- **SC-003**: The new module is included in the repository's documented
+  validation flow for maintained modules, or every exclusion is explicitly
+  documented before merge.
+- **SC-004**: README, examples, tests, and declared compatibility expectations
+  all match the final supported module interface at review time.
+- **SC-005**: No part of the delivered module requires consumers to understand
+  or supply the full upstream chart configuration surface for the standard use
+  case.
+- **SC-006**: A reviewer can map every supported consumer input to an explicit
+  documented Keycloak use case without relying on a generic chart-values
+  override mechanism.
+- **SC-007**: A reviewer can determine, from the README and example alone,
+  which bootstrap credential path is supported, how conflicting inputs are
+  handled, and which option is preferred for ongoing operations.

--- a/specs/002-keycloak-module/tasks.md
+++ b/specs/002-keycloak-module/tasks.md
@@ -1,0 +1,244 @@
+---
+
+description: "Task list for Keycloak Helm wrapper module"
+---
+
+# Tasks: Keycloak Helm Wrapper Module
+
+**Input**: Design documents from `/specs/002-keycloak-module/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Test tasks are included because the specification explicitly
+requires at least one example path, at least one test path, and validation for
+the new maintained module behavior.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Terraform module**: `modules/keycloak/`
+- **Examples**: `modules/keycloak/examples/basic/`
+- **Tests**: `modules/keycloak/tests/basic/`
+- **Automation**: `.github/workflows/`, `.pre-commit-config.yaml`
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the new module workspace and identify the repo-level
+validation touchpoints it must join
+
+- [X] T001 Create the Keycloak module file skeleton in `modules/keycloak/main.tf`, `modules/keycloak/variables.tf`, `modules/keycloak/outputs.tf`, `modules/keycloak/versions.tf`, and `modules/keycloak/README.md`
+- [X] T002 Create the support-artifact skeleton in `modules/keycloak/examples/basic/0-setup.tf`, `modules/keycloak/examples/basic/README.md`, `modules/keycloak/tests/basic/providers.tf`, `modules/keycloak/tests/basic/main.tf`, and `modules/keycloak/tests/basic/README.md`
+- [X] T003 [P] Capture the maintained-module validation touchpoints for `modules/keycloak` in `.github/workflows/checkov.yaml`, `.github/workflows/tflint.yaml`, `.github/workflows/terraform-test.yaml`, and `.pre-commit-config.yaml`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the shared compatibility baseline and curated interface
+shape that all user stories depend on
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T004 Define Terraform and provider compatibility for the module in `modules/keycloak/versions.tf`
+- [X] T005 [P] Define the shared curated inputs and validation rules for release identity, external database, ingress, and bootstrap credentials in `modules/keycloak/variables.tf`
+- [X] T006 [P] Establish the shared Helm values assembly and secret-source selection scaffolding in `modules/keycloak/main.tf`
+- [X] T007 Establish the stable output names and placeholder output wiring in `modules/keycloak/outputs.tf`
+
+**Checkpoint**: Foundation ready - user story work can now proceed in priority order
+
+---
+
+## Phase 3: User Story 1 - Deploy a Standard Keycloak Release (Priority: P1) 🎯 MVP
+
+**Goal**: Deliver one supported baseline Keycloak deployment path that matches
+the repository’s Helm-wrapper style
+
+**Independent Test**: Run the documented basic example from
+`modules/keycloak/examples/basic/` and confirm it represents one complete
+supported external-database Keycloak release without raw chart pass-through
+
+### Tests for User Story 1
+
+- [X] T008 [P] [US1] Add the baseline example consumer configuration in `modules/keycloak/examples/basic/1-example.tf`
+- [X] T009 [P] [US1] Add baseline Terraform validation coverage for the standard release path in `modules/keycloak/tests/basic/main.tf`
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Implement the standard external-database Keycloak Helm release path in `modules/keycloak/main.tf`
+- [X] T011 [P] [US1] Finalize the baseline release outputs in `modules/keycloak/outputs.tf`
+- [X] T012 [US1] Document baseline prerequisites, defaults, and supported usage in `modules/keycloak/README.md` and `modules/keycloak/examples/basic/README.md`
+- [X] T013 [US1] Run baseline validation for `modules/keycloak/`, `modules/keycloak/examples/basic/`, and `modules/keycloak/tests/basic/`
+
+**Checkpoint**: User Story 1 should now deliver a reviewable MVP module path
+
+---
+
+## Phase 4: User Story 2 - Customize the Common Keycloak Use Case (Priority: P2)
+
+**Goal**: Extend the baseline module with the common customization knobs teams
+actually need while preserving the curated wrapper boundary
+
+**Independent Test**: Review and validate the module interface, example, and
+test path to confirm hostname, ingress, external-database, and
+bootstrap-credential customization are supported without exposing the full
+upstream chart surface
+
+### Tests for User Story 2
+
+- [X] T014 [P] [US2] Extend the example and test inputs for hostname, ingress, and bootstrap credential mode selection in `modules/keycloak/examples/basic/1-example.tf` and `modules/keycloak/tests/basic/main.tf`
+
+### Implementation for User Story 2
+
+- [X] T015 [P] [US2] Implement curated customization inputs and conflict validation for ingress and bootstrap credential modes in `modules/keycloak/variables.tf`
+- [X] T016 [US2] Implement common-case override wiring for ingress, external database settings, and bootstrap secret source selection in `modules/keycloak/main.tf`
+- [X] T017 [US2] Update release outputs and consumer guidance for customization boundaries in `modules/keycloak/outputs.tf` and `modules/keycloak/README.md`
+- [X] T018 [US2] Re-run validation for the customization path in `modules/keycloak/`, `modules/keycloak/examples/basic/`, and `modules/keycloak/tests/basic/`
+
+**Checkpoint**: User Stories 1 and 2 should now be independently reviewable with a stable curated interface
+
+---
+
+## Phase 5: User Story 3 - Trust the Module Through Documentation and Validation (Priority: P3)
+
+**Goal**: Make the new module reviewable and adoptable as a maintained module
+through aligned docs, support artifacts, and workflow coverage
+
+**Independent Test**: Review `modules/keycloak/README.md`,
+`modules/keycloak/examples/basic/`, `modules/keycloak/tests/basic/`, and the
+workflow files to confirm the module is documented consistently and included in
+the maintained-module quality gates
+
+### Tests for User Story 3
+
+- [X] T019 [P] [US3] Finalize reviewable support guidance in `modules/keycloak/examples/basic/README.md` and `modules/keycloak/tests/basic/README.md`
+
+### Implementation for User Story 3
+
+- [X] T020 [P] [US3] Add `modules/keycloak` to the maintained-module matrix in `.github/workflows/checkov.yaml`
+- [X] T021 [P] [US3] Add `modules/keycloak` to the maintained-module matrices in `.github/workflows/tflint.yaml` and `.github/workflows/terraform-test.yaml`
+- [X] T022 [US3] Reconcile terraform-docs and formatting expectations for `modules/keycloak/README.md` under `.pre-commit-config.yaml`
+- [X] T023 [US3] Finalize maintainer-facing documentation alignment in `modules/keycloak/README.md`, `modules/keycloak/examples/basic/README.md`, and `modules/keycloak/tests/basic/README.md`
+- [X] T024 [US3] Validate maintained-module coverage and support-artifact alignment in `.github/workflows/checkov.yaml`, `.github/workflows/tflint.yaml`, `.github/workflows/terraform-test.yaml`, `modules/keycloak/README.md`, `modules/keycloak/examples/basic/README.md`, and `modules/keycloak/tests/basic/README.md`
+
+**Checkpoint**: All user stories should now be independently reviewable and the module should satisfy the maintained-module delivery bar
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency review and full-feature verification
+
+- [X] T025 [P] Reconcile all touched module files in `modules/keycloak/main.tf`, `modules/keycloak/variables.tf`, `modules/keycloak/outputs.tf`, `modules/keycloak/versions.tf`, and `modules/keycloak/README.md`
+- [X] T026 [P] Reconcile all touched support assets in `modules/keycloak/examples/basic/`, `modules/keycloak/tests/basic/`, and `.github/workflows/`
+- [X] T027 Re-run the full validation commands documented in `specs/002-keycloak-module/quickstart.md`
+- [X] T028 Review the final diff in `modules/keycloak/`, `.github/workflows/`, `.pre-commit-config.yaml`, and `specs/002-keycloak-module/` for wrapper drift, unsupported pass-through exposure, and stale documentation
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational completion
+- **User Story 2 (Phase 4)**: Depends on User Story 1 establishing the baseline module path
+- **User Story 3 (Phase 5)**: Depends on User Stories 1 and 2 so docs and workflow coverage reflect the final supported interface
+- **Polish (Phase 6)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: First deliverable and recommended MVP scope
+- **User Story 2 (P2)**: Extends the baseline from User Story 1 with supported common customizations
+- **User Story 3 (P3)**: Finalizes maintainability, documentation, and workflow inclusion after the interface is stable
+
+### Within Each User Story
+
+- Example/test updates before or alongside implementation
+- Variable validation before final resource wiring
+- Core Terraform implementation before final documentation sync
+- Story-specific validation before moving to the next phase
+
+### Parallel Opportunities
+
+- `T003` can run in parallel with `T001` and `T002`
+- `T005` and `T006` can run in parallel once the module skeleton exists
+- `T008` and `T009` can run in parallel within User Story 1
+- `T011` can run in parallel with `T012` after `T010` stabilizes the baseline release shape
+- `T014` and `T015` can run in parallel within User Story 2
+- `T020` and `T021` can run in parallel within User Story 3
+- `T025` and `T026` can run in parallel before the final validation pass
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch the baseline example and test tasks together:
+Task: "Add the baseline example consumer configuration in modules/keycloak/examples/basic/1-example.tf"
+Task: "Add baseline Terraform validation coverage for the standard release path in modules/keycloak/tests/basic/main.tf"
+```
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch disjoint customization tasks together:
+Task: "Extend the example and test inputs for hostname, ingress, and bootstrap credential mode selection in modules/keycloak/examples/basic/1-example.tf and modules/keycloak/tests/basic/main.tf"
+Task: "Implement curated customization inputs and conflict validation for ingress and bootstrap credential modes in modules/keycloak/variables.tf"
+```
+
+---
+
+## Parallel Example: User Story 3
+
+```bash
+# Launch independent workflow updates together:
+Task: "Add modules/keycloak to the maintained-module matrix in .github/workflows/checkov.yaml"
+Task: "Add modules/keycloak to the maintained-module matrices in .github/workflows/tflint.yaml and .github/workflows/terraform-test.yaml"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Stop and validate the baseline Keycloak deployment path
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational
+2. Deliver User Story 1 for the first supported Keycloak release path
+3. Deliver User Story 2 for common-case customization without interface drift
+4. Deliver User Story 3 for maintained-module reviewability and workflow coverage
+5. Finish with Polish and the full validation pass
+
+### Parallel Team Strategy
+
+1. One contributor establishes the shared module skeleton and compatibility baseline
+2. After Foundational completes:
+   - Contributor A handles the baseline module implementation and outputs for User Story 1
+   - Contributor B prepares customization-facing example/test inputs and variable validation for User Story 2
+   - Contributor C prepares workflow coverage updates and support-asset guidance for User Story 3 once the interface stabilizes
+3. Merge at the Polish phase for full validation and wrapper-boundary review
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] labels map every story-phase task to the corresponding user story
+- Every user story has an explicit independent test criterion
+- The suggested MVP scope is User Story 1 only
+- Do not add generic Helm values pass-through or undocumented advanced chart options during implementation


### PR DESCRIPTION
## Summary
- add a new `modules/keycloak` Terraform wrapper around the `codecentric/keycloakx` Helm chart
- keep the first-version interface narrow with explicit external database, ingress, and bootstrap secret inputs
- add aligned README, example, test scaffolding, workflow coverage, spec-kit artifacts, and repo-local Terraform pinning via `asdf`

## Review Focus
- verify the wrapper boundary stays opinionated and does not expose generic Helm values pass-through
- verify the two supported credential paths: raw passwords materialized into Kubernetes Secrets and consumer-managed existing Secret references
- verify the maintained-module workflow additions for `checkov`, `tflint`, and `terraform-test`

## Validation
- `asdf exec terraform fmt -check -recursive modules/keycloak`
- `asdf exec terraform -chdir=modules/keycloak init -backend=false && validate`
- `asdf exec terraform -chdir=modules/keycloak/examples/basic init -backend=false && validate`
- `asdf exec terraform -chdir=modules/keycloak/tests/basic init -backend=false && validate`
- `PATH="$HOME/.asdf/shims:$PATH" PRE_COMMIT_HOME=/tmp/pre-commit-cache python3 -m pre_commit run --files modules/keycloak/main.tf modules/keycloak/variables.tf modules/keycloak/outputs.tf modules/keycloak/versions.tf modules/keycloak/README.md modules/keycloak/examples/basic/0-setup.tf modules/keycloak/examples/basic/1-example.tf modules/keycloak/examples/basic/README.md modules/keycloak/tests/basic/providers.tf modules/keycloak/tests/basic/main.tf modules/keycloak/tests/basic/README.md .github/workflows/checkov.yaml .github/workflows/tflint.yaml .github/workflows/terraform-test.yaml`
